### PR TITLE
Fix a file browsing error

### DIFF
--- a/lua/luapad/client/luapad.lua
+++ b/lua/luapad/client/luapad.lua
@@ -70,7 +70,14 @@ end
 hook.Add( "ShutDown", "luapad.SaveTabs", luapad.SaveTabs )
 
 local function loadSavedTabs()
-    if not file.Exists( "luapad/_tabs.dat", "DATA" ) then return end
+    if not file.Exists( "luapad/_tabs.dat", "DATA" ) then
+        if file.Exists( "luapad/_tabs.txt", "DATA" ) then
+            file.Rename( "luapad/_tabs.txt", "luapad/_tabs.dat" )
+        else
+            return
+        end
+    end
+
     local store = util.JSONToTable( util.Decompress( file.Read( "luapad/_tabs.dat", "DATA" ):sub( 8 ) ) )
 
     if store then


### PR DESCRIPTION
Trying to expand the `luapad` node in the file open dialog when the folder only contains `_tabs.txt` throws an error related to DTreeNode, this fixes that by changing the tabs file to use the .dat extension instead and limiting the node population to .txt files only.

```
[ERROR] lua/vgui/dtree_node.lua:239: attempt to index a nil value
  1. DoChildrenOrder - lua/vgui/dtree_node.lua:239
   2. unknown - lua/vgui/dtree_node.lua:305
    3. InvalidateLayout - [C]:-1
     4. SetExpanded - lua/vgui/dtree_node.lua:201
      5. DoClick - lua/vgui/dtree_node.lua:39
       6. unknown - lua/vgui/dlabel.lua:254
```

If maintaining existing tabs is important enough I can add a bit of extra code that checks if `_tabs.txt` exists and if it does (and `_tabs.dat` doesn't) it renames the file.