### PR TITLE
Only open a new tab if we don't have any saved

### DIFF
--- a/lua/luapad/client/luapad.lua
+++ b/lua/luapad/client/luapad.lua
@@ -240,10 +240,13 @@ function luapad.Toggle()
 
     luapad.PropertySheet:InvalidateLayout()
 
-    luapad.NewTab()
 
     setupToolbar()
     loadSavedTabs()
+
+    if table.Count( luapad.PropertySheet.Items ) == 0 then
+        luapad.NewTab()
+    end
 end
 
 function luapad.AddTab( name, content, path )


### PR DESCRIPTION
This changes the loader to only add an empty tab if there aren't any saved tabs, fixing instances where you would load into a map and be presented with both an empty tab and your empty (or filled) tab from your last session.