### PR TITLE
Browse Lua for Sandbox Spawn Menu

### DIFF
--- a/lua/autorun/sh_luapad_loader.lua
+++ b/lua/autorun/sh_luapad_loader.lua
@@ -34,6 +34,7 @@ include_client( "luapad/client/auth.lua" )
 include_client( "luapad/client/functions.lua" )
 include_client( "luapad/client/luapad.lua" )
 include_client( "luapad/client/settings.lua" )
+include_client( "luapad/client/spawnmenu.lua" )
 
 include_server( "luapad/server/auth.lua" )
 include_server( "luapad/server/code_execution.lua" )

--- a/lua/luapad/client/luapad.lua
+++ b/lua/luapad/client/luapad.lua
@@ -344,7 +344,7 @@ end
 
 function luapad.OpenFile( path )
     if not path then return end
-    
+
     local content = file.Read( path, "GAME" )
     if not content then return end
 

--- a/lua/luapad/client/luapad.lua
+++ b/lua/luapad/client/luapad.lua
@@ -193,11 +193,9 @@ local function setupToolbar()
     end
 end
 
-function luapad.Toggle( path )
+function luapad.Toggle( noNewTab )
     if IsValid( luapad.Frame ) then
         luapad.Frame:SetVisible( not luapad.Frame:IsVisible() )
-        luapad.OpenFile( path )
-
         return
     end
 
@@ -229,6 +227,7 @@ function luapad.Toggle( path )
     luapad.PropertySheet.tabScroller:DockMargin( 0, 0, 0, 0 )
     luapad.PropertySheet.tabScroller:SetOverlap( 0 )
     luapad.PropertySheet.____SetActiveTab = luapad.PropertySheet.SetActiveTab
+    
     function luapad.PropertySheet:SetActiveTab( ... )
         luapad.PropertySheet:____SetActiveTab( ... )
 
@@ -237,6 +236,7 @@ function luapad.Toggle( path )
             luapad.Frame:SetTitle( "Luapad - " .. panel.path .. panel.name )
         end
     end
+
     luapad.PropertySheet.tabScroller:SetTall( 22 )
     luapad.PropertySheet.tabScroller.SetTall = function() end
     luapad.PropertySheet.Paint = function() end
@@ -259,11 +259,7 @@ function luapad.Toggle( path )
     setupToolbar()
     loadSavedTabs()
 
-    if path then
-        return luapad.OpenFile( path )
-    end
-
-    if table.Count( luapad.PropertySheet.Items ) == 0 then
+    if not noNewTab and table.Count( luapad.PropertySheet.Items ) == 0 then
         luapad.NewTab()
     end
 end

--- a/lua/luapad/client/luapad.lua
+++ b/lua/luapad/client/luapad.lua
@@ -227,7 +227,7 @@ function luapad.Toggle( noNewTab )
     luapad.PropertySheet.tabScroller:DockMargin( 0, 0, 0, 0 )
     luapad.PropertySheet.tabScroller:SetOverlap( 0 )
     luapad.PropertySheet.____SetActiveTab = luapad.PropertySheet.SetActiveTab
-    
+
     function luapad.PropertySheet:SetActiveTab( ... )
         luapad.PropertySheet:____SetActiveTab( ... )
 
@@ -351,7 +351,7 @@ function luapad.OpenFile( path )
     local fileName = string.GetFileFromFilename( path )
     local pathNoName = string.GetPathFromFilename( path )
 
-    for k, item in pairs( luapad.PropertySheet.Items ) do
+    for _, item in pairs( luapad.PropertySheet.Items ) do
         local tab = item.Tab
 
         if tab.FilePath == path then

--- a/lua/luapad/client/spawnmenu.lua
+++ b/lua/luapad/client/spawnmenu.lua
@@ -8,11 +8,11 @@ local function onNodeSelected( self, node )
 
     local files = file.Find( path .. "/*", self.SearchPath )
 
-    for k, fileName in ipairs( files ) do
-        spawnmenu.CreateContentIcon( "gamefile", viewPanel, { 
+    for _, fileName in ipairs( files ) do
+        spawnmenu.CreateContentIcon( "gamefile", viewPanel, {
             fileName = fileName,
             filePath = path .. "/" .. fileName
-        })
+        } )
     end
 
     self.pnlContent:SwitchPanel( viewPanel )
@@ -34,7 +34,7 @@ end
 local function recursiveAddLua( mainNode, node, path, searchPath )
     local _, dirs = file.Find( path .. "*", searchPath )
 
-    for k, dir in ipairs( dirs ) do
+    for _, dir in ipairs( dirs ) do
         local folderPath = path .. dir
         local folder = addFolderNode( mainNode, node, dir, "icon16/folder.png", folderPath, searchPath )
 
@@ -58,7 +58,7 @@ local function refreshGModLua( node )
 end
 
 local function refreshAddonLuaFiles( node )
-    for k, addon in SortedPairsByMemberValue( engine.GetAddons(), "title" ) do
+    for _, addon in SortedPairsByMemberValue( engine.GetAddons(), "title" ) do
         if addon.downloaded and addon.mounted then
             local title = addon.title
 
@@ -80,11 +80,11 @@ local function refreshLegacyAddonLuaFiles( node )
     local legacyAddons = {}
     local _, dirs = file.Find( "addons/*", "GAME" )
 
-    if not dirs[1] then 
+    if not dirs[1] then
         return node:Remove()
     end
 
-    for k, addon in ipairs( dirs ) do
+    for _, addon in ipairs( dirs ) do
         table.insert( legacyAddons, addon )
     end
 

--- a/lua/luapad/client/spawnmenu.lua
+++ b/lua/luapad/client/spawnmenu.lua
@@ -52,11 +52,6 @@ local function deleteIfEmpty( node )
     end
 end
 
-local function refreshGModLua( node )
-    recursiveAddLua( node, node, "lua/", "MOD" )
-    deleteIfEmpty( node )
-end
-
 local function refreshAddonLuaFiles( node )
     for _, addon in SortedPairsByMemberValue( engine.GetAddons(), "title" ) do
         if addon.downloaded and addon.mounted then
@@ -133,7 +128,8 @@ hook.Add( "PopulateContent", "SpawnmenuLuapadBrowse", function( panelContent, tr
 
         refreshAddonLuaFiles( browseAddonLua )
         refreshLegacyAddonLuaFiles( browseLegacyLua )
-        refreshGModLua( browseGmodLua )
+        
+        recursiveAddLua( browseGmodLua, browseGmodLua, "lua/", "MOD" )
     end)
 end)
 

--- a/lua/luapad/client/spawnmenu.lua
+++ b/lua/luapad/client/spawnmenu.lua
@@ -95,9 +95,9 @@ local function refreshLegacyAddonLuaFiles( node )
         local hasLua = files[1] or dirs[1]
 
         if hasLua then
-            local luaFiles = addFolderNode( node, node, addon, "icon16/bricks.png", "addons/" .. addon .. "/lua" )
+            local luaFiles = addFolderNode( node, node, addon, "icon16/bricks.png", "addons/" .. addon .. "/lua", "GAME" )
 
-            recursiveAddLua( node, luaFiles, "addons/" .. addon .. "/", "GAME" )
+            recursiveAddLua( node, luaFiles, "addons/" .. addon .. "/lua/", "GAME" )
         end
     end
 
@@ -152,10 +152,11 @@ spawnmenu.AddContentType( "gamefile", function( container, obj )
         local function openFile()
             if IsValid( luapad.Frame ) then
                 luapad.Frame:SetVisible( true )
-                luapad.OpenFile( obj.filePath )
             else
-                luapad.Toggle( obj.filePath )
+                luapad.Toggle( true )
             end
+
+            luapad.OpenFile( obj.filePath )
 
             local spawnMenu = g_SpawnMenu
 

--- a/lua/luapad/client/spawnmenu.lua
+++ b/lua/luapad/client/spawnmenu.lua
@@ -176,7 +176,7 @@ spawnmenu.AddContentType( "gamefile", function( container, obj )
 		menu:Open()
 	end
 
-	if ( IsValid( container ) ) then
+	if IsValid( container ) then
 		container:Add( icon )
 	end
 

--- a/lua/luapad/client/spawnmenu.lua
+++ b/lua/luapad/client/spawnmenu.lua
@@ -1,0 +1,188 @@
+-- Browse Lua Files for the Sandbox Spawn Menu
+
+local function onNodeSelected( self, node )
+    local viewPanel = self.ViewPanel
+    local path = self.Path
+
+    viewPanel:Clear()
+
+    local files = file.Find( path .. "/*", self.SearchPath )
+
+    for k, fileName in ipairs( files ) do
+        spawnmenu.CreateContentIcon( "gamefile", viewPanel, { 
+            fileName = fileName,
+            filePath = path .. "/" .. fileName
+        })
+    end
+
+    self.pnlContent:SwitchPanel( viewPanel )
+end
+
+local function addFolderNode( mainNode, node, name, icon, path, searchPath )
+    local folderNode = node:AddNode( name, icon )
+
+    folderNode.ViewPanel = mainNode.ViewPanel
+    folderNode.pnlContent = mainNode.pnlContent
+
+    folderNode.Path = path
+    folderNode.SearchPath = searchPath
+    folderNode.OnNodeSelected = onNodeSelected
+
+    return folderNode
+end
+
+local function recursiveAddLua( mainNode, node, path, searchPath )
+    local _, dirs = file.Find( path .. "*", searchPath )
+
+    for k, dir in ipairs( dirs ) do
+        local folderPath = path .. dir
+        local folder = addFolderNode( mainNode, node, dir, "icon16/folder.png", folderPath, searchPath )
+
+        local _, subDirs = file.Find( folderPath .. "/*", searchPath )
+
+        if subDirs[1] then
+            recursiveAddLua( mainNode, folder, folderPath .. "/", searchPath )
+        end
+    end
+end
+
+local function deleteIfEmpty( node )
+    if #node:GetChildNodes() <= 0 then
+        node:Remove()
+    end
+end
+
+local function refreshGModLua( node )
+    recursiveAddLua( node, node, "lua/", "MOD" )
+    deleteIfEmpty( node )
+end
+
+local function refreshAddonLuaFiles( node )
+    for k, addon in SortedPairsByMemberValue( engine.GetAddons(), "title" ) do
+        if addon.downloaded and addon.mounted then
+            local title = addon.title
+
+            local files, dirs = file.Find( "lua/*", title )
+            local hasLua = files[1] or dirs[1]
+
+            if hasLua then
+                local luaFiles = addFolderNode( node, node, title, "icon16/bricks.png", "lua", title )
+
+                recursiveAddLua( node, luaFiles, "lua/", title )
+            end
+        end
+    end
+
+    deleteIfEmpty( node )
+end
+
+local function refreshLegacyAddonLuaFiles( node )
+    local legacyAddons = {}
+    local _, dirs = file.Find( "addons/*", "GAME" )
+
+    if not dirs[1] then 
+        return node:Remove()
+    end
+
+    for k, addon in ipairs( dirs ) do
+        table.insert( legacyAddons, addon )
+    end
+
+    table.sort( legacyAddons )
+
+    for k, addon in ipairs( legacyAddons ) do
+        local files, dirs = file.Find( "addons/" .. addon .. "/lua/*", "GAME" )
+        local hasLua = files[1] or dirs[1]
+
+        if hasLua then
+            local luaFiles = addFolderNode( node, node, addon, "icon16/bricks.png", "addons/" .. addon .. "/lua" )
+
+            recursiveAddLua( node, luaFiles, "addons/" .. addon .. "/", "GAME" )
+        end
+    end
+
+    deleteIfEmpty( node )
+end
+
+hook.Add( "PopulateContent", "SpawnmenuLuapadBrowse", function( panelContent, tree )
+    timer.Simple( 0.1, function() -- Make sure this is added after normal Browse is created
+        local viewPanel = tree:Add( "ContentContainer" )
+
+        viewPanel:SetVisible( false )
+
+        local function createTreeNode( name, icon, parent )
+            parent = parent or tree
+
+            local newTree = parent:AddNode( name, icon )
+        
+            newTree.pnlContent = panelContent
+            newTree.ViewPanel = viewPanel
+        
+            return newTree
+        end
+
+        local browseLua = createTreeNode( "#spawnmenu.category.browselua", "icon16/page_white_text.png" )
+        local browseLuapad = createTreeNode( "#spawnmenu.category.luapadlua", "icon16/folder.png", browseLua )
+        local browseAddonLua = createTreeNode( "#spawnmenu.category.addons", "icon16/folder.png", browseLua )
+        local browseLegacyLua = createTreeNode( "#spawnmenu.category.addonslegacy", "icon16/folder.png", browseLua )
+        local browseGmodLua = createTreeNode( "Garry's Mod", "games/16/garrysmod.png", browseLua )
+
+        browseLuapad.OnNodeSelected = onNodeSelected
+        browseLuapad.Path = "data/luapad"
+        browseLuapad.SearchPath = "GAME"
+
+        refreshAddonLuaFiles( browseAddonLua )
+        refreshLegacyAddonLuaFiles( browseLegacyLua )
+        refreshGModLua( browseGmodLua )
+    end)
+end)
+
+language.Add( "spawnmenu.category.browselua", "Browse Lua" )
+language.Add( "spawnmenu.category.luapadlua", "Luapad Storage" )
+
+spawnmenu.AddContentType( "gamefile", function( container, obj )
+	local icon = vgui.Create( "ContentIcon", container )
+    
+	icon:SetContentType( "gamefile" )
+	icon:SetSpawnName( obj.filePath )
+	icon:SetName( obj.fileName )
+	icon:SetMaterial( "icon16/page_white_text.png" )
+
+	icon.DoClick = function()
+        local function openFile()
+            if IsValid( luapad.Frame ) then
+                luapad.Frame:SetVisible( true )
+                luapad.OpenFile( obj.filePath )
+            else
+                luapad.Toggle( obj.filePath )
+            end
+
+            local spawnMenu = g_SpawnMenu
+
+            if IsValid( spawnMenu ) then
+                spawnMenu:Close()
+            end
+        end
+
+        if luapad.CanUseCL() then
+            return openFile()
+        end
+    
+        luapad.RequestCLAuth( openFile )
+	end
+
+	icon.OpenMenu = function( icn )
+		local menu = DermaMenu()
+			menu:AddOption( "#spawnmenu.menu.copy", function() SetClipboardText( obj.filePath ) end ):SetIcon( "icon16/page_copy.png" )
+			menu:AddSpacer()
+			menu:AddOption( "#spawnmenu.menu.delete", function() icn:Remove() hook.Run( "SpawnlistContentChanged", icn ) end ):SetIcon( "icon16/bin_closed.png" )
+		menu:Open()
+	end
+
+	if ( IsValid( container ) ) then
+		container:Add( icon )
+	end
+
+	return icon
+
+end )

--- a/lua/luapad/client/spawnmenu.lua
+++ b/lua/luapad/client/spawnmenu.lua
@@ -1,6 +1,6 @@
 -- Browse Lua Files for the Sandbox Spawn Menu
 
-local function onNodeSelected( self, node )
+local function onNodeSelected( self )
     local viewPanel = self.ViewPanel
     local path = self.Path
 

--- a/lua/luapad/client/spawnmenu.lua
+++ b/lua/luapad/client/spawnmenu.lua
@@ -72,20 +72,15 @@ local function refreshAddonLuaFiles( node )
 end
 
 local function refreshLegacyAddonLuaFiles( node )
-    local legacyAddons = {}
-    local _, dirs = file.Find( "addons/*", "GAME" )
+    local _, legacyAddons = file.Find( "addons/*", "GAME" )
 
-    if not dirs[1] then
+    if not legacyAddons[1] then
         return node:Remove()
-    end
-
-    for _, addon in ipairs( dirs ) do
-        table.insert( legacyAddons, addon )
     end
 
     table.sort( legacyAddons )
 
-    for k, addon in ipairs( legacyAddons ) do
+    for _, addon in ipairs( legacyAddons ) do
         local files, dirs = file.Find( "addons/" .. addon .. "/lua/*", "GAME" )
         local hasLua = files[1] or dirs[1]
 
@@ -109,10 +104,10 @@ hook.Add( "PopulateContent", "SpawnmenuLuapadBrowse", function( panelContent, tr
             parent = parent or tree
 
             local newTree = parent:AddNode( name, icon )
-        
+
             newTree.pnlContent = panelContent
             newTree.ViewPanel = viewPanel
-        
+
             return newTree
         end
 
@@ -130,15 +125,15 @@ hook.Add( "PopulateContent", "SpawnmenuLuapadBrowse", function( panelContent, tr
         refreshLegacyAddonLuaFiles( browseLegacyLua )
         
         recursiveAddLua( browseGmodLua, browseGmodLua, "lua/", "MOD" )
-    end)
-end)
+    end )
+end )
 
 language.Add( "spawnmenu.category.browselua", "Browse Lua" )
 language.Add( "spawnmenu.category.luapadlua", "Luapad Storage" )
 
 spawnmenu.AddContentType( "gamefile", function( container, obj )
 	local icon = vgui.Create( "ContentIcon", container )
-    
+
 	icon:SetContentType( "gamefile" )
 	icon:SetSpawnName( obj.filePath )
 	icon:SetName( obj.fileName )
@@ -164,7 +159,7 @@ spawnmenu.AddContentType( "gamefile", function( container, obj )
         if luapad.CanUseCL() then
             return openFile()
         end
-    
+
         luapad.RequestCLAuth( openFile )
 	end
 


### PR DESCRIPTION
Adds a "Browse Lua" category to the spawn menu, like how Extended Spawn Menu does.
![luapad_browse_lua](https://github.com/user-attachments/assets/9994e54f-c591-4fd2-bbb8-af195c0c4b62)

You can view the Lua files of the base game, your local Luapad saves, your subscribed workshop addons, and your local addons. Clicking on a Lua file via the spawn menu automatically opens up Luapad for you to view it. 

(I also fixed a bug where saving files doesn't work because `luapad` directory is never created)