### PR TITLE
Fix inconsistencies with console history

### DIFF
--- a/lua/luapad/client/luapad_consolepanel.lua
+++ b/lua/luapad/client/luapad_consolepanel.lua
@@ -88,14 +88,15 @@ function PANEL:Init()
             return
         end
 
-        local exists = table.KeyFromValue( self.Input.History, text )
-        if not exists then
+        if self.Input.History[#self.Input.History] ~= text then
             table.insert( self.Input.History, text )
 
             if #self.Input.History > 10 then
                 table.remove( self.Input.History, 1 )
             end
         end
+
+        self.Input.HistoryPos = 0
 
         local isClient = self.Realm:GetValue() == "Client"
         local isServer = self.Realm:GetValue() == "Server"


### PR DESCRIPTION
Properly resets the HistoryPos on the DTextEntry when submitted and makes it write to history whenever the last line isn't the same as the one we just submitted

This fixes having to go up and then down the history to recall the last line you just typed and some confusing situations where pressing up arrow after submitting a line doesn't bring up the exact line you just submitted because you've typed that line before